### PR TITLE
CI: Initial required workflow

### DIFF
--- a/.github/workflows/gerrit-required-verify.yaml
+++ b/.github/workflows/gerrit-required-verify.yaml
@@ -1,0 +1,93 @@
+---
+name: Gerrit Required Verify
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+    inputs:
+      GERRIT_BRANCH:
+        description: "Branch that change is against"
+        required: true
+        type: string
+      GERRIT_CHANGE_ID:
+        description: "The ID for the change"
+        required: true
+        type: string
+      GERRIT_CHANGE_NUMBER:
+        description: "The Gerrit number"
+        required: true
+        type: string
+      GERRIT_CHANGE_URL:
+        description: "URL to the change"
+        required: true
+        type: string
+      GERRIT_EVENT_TYPE:
+        description: "Gerrit event type"
+        required: true
+        type: string
+      GERRIT_PATCHSET_NUMBER:
+        description: "The patch number for the change"
+        required: true
+        type: string
+      GERRIT_PATCHSET_REVISION:
+        description: "The revision sha"
+        required: true
+        type: string
+      GERRIT_PROJECT:
+        description: "Project in Gerrit"
+        required: true
+        type: string
+      GERRIT_REFSPEC:
+        description: "Gerrit refspec of change"
+        required: true
+        type: string
+      TARGET_REPO:
+        # yamllint disable-line rule:line-length
+        description: "The target GitHub repository needing the required workflow"
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  # prepare:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Clear votes
+  #       uses: lfit/gerrit-review-action@v0.3
+  #       with:
+  #         host: ${{ vars.LFIT_GERRIT_SERVER }}
+  #         username: ${{ vars.LFIT_GERRIT_SSH_REQUIRED_USER }}
+  #         key: ${{ secrets.LFIT_GERRIT_SSH_REQUIRED_PRIVKEY }}
+  #         known_hosts: ${{ vars.LFIT_GERRIT_KNOWN_HOSTS }}
+  #         gerrit-change-number: ${{ inputs.GERRIT_CHANGE_NUMBER }}
+  #         gerrit-patchset-number: ${{ inputs.GERRIT_PATCHSET_NUMBER }}
+  #         vote-type: clear
+  #     - name: Allow replication
+  #       run: sleep 10s
+
+  # vote:
+  #   if: ${{ always() }}
+  #   needs: [prepare]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: technote-space/workflow-conclusion-action@v3
+  #     - name: Set vote
+  #       uses: lfit/gerrit-review-action@v0.3
+  #       with:
+  #         host: ${{ vars.LFIT_GERRIT_SERVER }}
+  #         username: ${{ vars.LFIT_GERRIT_SSH_REQUIRED_USER }}
+  #         key: ${{ secrets.LFIT_GERRIT_SSH_REQUIRED_PRIVKEY }}
+  #         known_hosts: ${{ vars.LFIT_GERRIT_KNOWN_HOSTS }}
+  #         gerrit-change-number: ${{ inputs.GERRIT_CHANGE_NUMBER }}
+  #         gerrit-patchset-number: ${{ inputs.GERRIT_PATCHSET_NUMBER }}
+  #         vote-type: ${{ env.WORKFLOW_CONCLUSION }}
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hello
+        run: |
+          echo "Hello World"
+        shell: bash


### PR DESCRIPTION
Add a basic non-blocking required workflow. This workflow is not doing
any voting and is just validating that required workflows are properly
firing.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
