### PR TITLE
Feat: Expand required verify job

### DIFF
--- a/.github/workflows/gerrit-required-verify.yaml
+++ b/.github/workflows/gerrit-required-verify.yaml
@@ -52,42 +52,66 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # prepare:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Clear votes
-  #       uses: lfit/gerrit-review-action@v0.3
-  #       with:
-  #         host: ${{ vars.LFIT_GERRIT_SERVER }}
-  #         username: ${{ vars.LFIT_GERRIT_SSH_REQUIRED_USER }}
-  #         key: ${{ secrets.LFIT_GERRIT_SSH_REQUIRED_PRIVKEY }}
-  #         known_hosts: ${{ vars.LFIT_GERRIT_KNOWN_HOSTS }}
-  #         gerrit-change-number: ${{ inputs.GERRIT_CHANGE_NUMBER }}
-  #         gerrit-patchset-number: ${{ inputs.GERRIT_PATCHSET_NUMBER }}
-  #         vote-type: clear
-  #     - name: Allow replication
-  #       run: sleep 10s
-
-  # vote:
-  #   if: ${{ always() }}
-  #   needs: [prepare]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: technote-space/workflow-conclusion-action@v3
-  #     - name: Set vote
-  #       uses: lfit/gerrit-review-action@v0.3
-  #       with:
-  #         host: ${{ vars.LFIT_GERRIT_SERVER }}
-  #         username: ${{ vars.LFIT_GERRIT_SSH_REQUIRED_USER }}
-  #         key: ${{ secrets.LFIT_GERRIT_SSH_REQUIRED_PRIVKEY }}
-  #         known_hosts: ${{ vars.LFIT_GERRIT_KNOWN_HOSTS }}
-  #         gerrit-change-number: ${{ inputs.GERRIT_CHANGE_NUMBER }}
-  #         gerrit-patchset-number: ${{ inputs.GERRIT_PATCHSET_NUMBER }}
-  #         vote-type: ${{ env.WORKFLOW_CONCLUSION }}
-  test:
+  prepare:
     runs-on: ubuntu-latest
     steps:
-      - name: Hello
+      - name: Clear votes
+        uses: lfit/gerrit-review-action@v0.3
+        with:
+          host: ${{ vars.LFIT_GERRIT_SERVER }}
+          username: ${{ vars.LFIT_GERRIT_SSH_REQUIRED_USER }}
+          key: ${{ secrets.LFIT_GERRIT_SSH_REQUIRED_PRIVKEY }}
+          known_hosts: ${{ vars.LFIT_GERRIT_KNOWN_HOSTS }}
+          gerrit-change-number: ${{ inputs.GERRIT_CHANGE_NUMBER }}
+          gerrit-patchset-number: ${{ inputs.GERRIT_PATCHSET_NUMBER }}
+          vote-type: clear
+      - name: Allow replication
+        run: sleep 10s
+
+  needs-validate:
+    runs-on: ubuntu-latest
+    outputs:
+      validate: ${{ steps.repo-name.outputs.VALIDATE }}
+    steps:
+      - name: Check repo name
+        id: repo-name
+        env:
+          TARGET_REPO: ${{ vars.TARGET_REPO }}
         run: |
-          echo "Hello World"
+          if [[ "${TARGET_REPO}" == puppet-* ]]; then
+            echo "VALIDATE=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "VALIDATE=false" >> "$GITHUB_OUTPUT"
+          fi
         shell: bash
+
+  gpg-validate:
+    runs-on: ubuntu-latest
+    needs: [prepare, needs-validate]
+    if: needs.needs-validate.outputs.validate == 'true'
+    steps:
+      - name: Checkout change
+        run: |
+          echo "Placeholder"
+        shell: bash
+
+  vote:
+    if: ${{ always() }}
+    needs: [prepare, needs-validate, gpg-validate]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: technote-space/workflow-conclusion-action@v3
+      - name: Resolution
+        run: |
+          echo ${{ env.WORKFLOW_CONCLUSION }}
+        shell: bash
+        # - name: Set vote
+        #   uses: lfit/gerrit-review-action@v0.3
+        #   with:
+        #     host: ${{ vars.LFIT_GERRIT_SERVER }}
+        #     username: ${{ vars.LFIT_GERRIT_SSH_REQUIRED_USER }}
+        #     key: ${{ secrets.LFIT_GERRIT_SSH_REQUIRED_PRIVKEY }}
+        #     known_hosts: ${{ vars.LFIT_GERRIT_KNOWN_HOSTS }}
+        #     gerrit-change-number: ${{ inputs.GERRIT_CHANGE_NUMBER }}
+        #     gerrit-patchset-number: ${{ inputs.GERRIT_PATCHSET_NUMBER }}
+        #     vote-type: ${{ env.WORKFLOW_CONCLUSION }}


### PR DESCRIPTION
Add more steps to the required verify job.

* Add a clear vote step to announce the start of the job
* Add a needs-validate step to determine if gpg validation needs to
  happen
* Add a gpg-validate place-holder step for build out of the gpg
  validation for puppet-* repos
* Add a final capture step which will be used for voting but at present
  just announces the final verdict without reporting back

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
