### PR TITLE
CI: Output the VERIFY header on error

### DIFF
--- a/.github/workflows/gerrit-required-verify.yaml
+++ b/.github/workflows/gerrit-required-verify.yaml
@@ -154,10 +154,16 @@ jobs:
               echo "Trusted signature found"
             else
               echo "ERROR: PGP Signature does not pass validation"
+              echo
+              echo "VERIFY is:"
+              echo "${VERIFY}"
               exit 1
             fi
           else
             echo "ERROR: PGP signature missing or not trusted"
+              echo
+              echo "VERIFY is:"
+              echo "${VERIFY}"
             exit 1
           fi
       - name: Cleanup GNUPGHOME


### PR DESCRIPTION
Output what VERIFY is holding if the signature check fails so that we
can debug what happened.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
