### PR TITLE
CI: Check trustdb after importing trust anchors

### DIFF
--- a/.github/workflows/gerrit-required-verify.yaml
+++ b/.github/workflows/gerrit-required-verify.yaml
@@ -142,6 +142,7 @@ jobs:
           cat "${OWNERTRUST}"
           gpg --import-ownertrust "${OWNERTRUST}"
           rm "${OWNERTRUST}"
+          gpg --check-trustdb
       - name: Verify Commit Signature
         shell: bash
         run: |


### PR DESCRIPTION
Make sure the trustdb is fully up to date after the trust anchor import
has happened.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
