### PR TITLE
CI: Add zizmor auditor configuration

### DIFF
--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,21 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+# zizmor configuration for the lfit/.github organization workflows.
+#
+# The Gerrit "required" workflows must vote on Gerrit changes using a
+# dedicated SSH service account. That credential is an organization
+# secret consumed directly by the gerrit-review-action; it cannot be
+# scoped to a GitHub deployment environment because environment secrets
+# do not propagate correctly into the reusable workflows these callers
+# invoke (doing so would require "secrets: inherit", which zizmor flags
+# via secrets-inherit). These credentials are therefore allow-listed for
+# the auditor-only secrets-outside-env audit.
+rules:
+  secrets-outside-env:
+    config:
+      allow:
+        - LFIT_GERRIT_SSH_REQUIRED_PRIVKEY
+        - LFIT_GERRIT_SSH_BYPASSABLE_PRIVKEY
+        - RTD_TOKEN


### PR DESCRIPTION
## Summary

Establishes a shared [zizmor](https://docs.zizmor.sh) policy for the
organization's Gerrit "required" workflows so they pass the strict
`--persona=auditor` scan with **zero findings**.

This is the first of a small series of atomic changes that modernise the
Linux Foundation Gerrit verification/merge CI to standardise on the
centrally-managed reusable workflows in `lfit/releng-reusable-workflows`.
It lands the audit configuration on its own so each subsequent workflow
change stays focused and independently reviewable.

## What & why

The Gerrit verification and merge workflows vote on changes using
dedicated SSH service accounts, and the RTDv3 reusables require an RTD API
token. These are organization secrets consumed directly by the actions.
They cannot be scoped to a GitHub deployment environment because
environment secrets do not propagate correctly into reusable workflows
(that would require `secrets: inherit`, which is itself flagged by
zizmor's `secrets-inherit` audit).

Allow-listing these credentials for the auditor-only `secrets-outside-env`
audit is the remediation [sanctioned by zizmor](https://docs.zizmor.sh/audits/#secrets-outside-env)
for exactly this situation.

Allow-listed secrets (forward-looking, covering the workflows added in the
follow-up changes):

- `LFIT_GERRIT_SSH_REQUIRED_PRIVKEY` — required-check voting account
- `LFIT_GERRIT_SSH_BYPASSABLE_PRIVKEY` — bypassable-check voting account
- `RTD_TOKEN` — Read the Docs v3 API token

## Validation

- `zizmor --persona=auditor --offline` → auto-discovers this config
- `yamllint` → clean
