### PR TITLE
CI: Add Gerrit change isolation verify workflow

### DIFF
--- a/.github/workflows/gerrit-required-change-isolation-verify.yaml
+++ b/.github/workflows/gerrit-required-change-isolation-verify.yaml
@@ -1,0 +1,121 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+name: Gerrit Required Change Isolation Verify
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+    inputs:
+      GERRIT_BRANCH:
+        description: "Branch that change is against"
+        required: true
+        type: string
+      GERRIT_CHANGE_ID:
+        description: "The ID for the change"
+        required: true
+        type: string
+      GERRIT_CHANGE_NUMBER:
+        description: "The Gerrit number"
+        required: true
+        type: string
+      GERRIT_CHANGE_URL:
+        description: "URL to the change"
+        required: true
+        type: string
+      GERRIT_EVENT_TYPE:
+        description: "Type of Gerrit event"
+        required: true
+        type: string
+      GERRIT_PATCHSET_NUMBER:
+        description: "The patch number for the change"
+        required: true
+        type: string
+      GERRIT_PATCHSET_REVISION:
+        description: "The revision sha"
+        required: true
+        type: string
+      GERRIT_PROJECT:
+        description: "Project in Gerrit"
+        required: true
+        type: string
+      GERRIT_REFSPEC:
+        description: "Gerrit refspec of change"
+        required: true
+        type: string
+      TARGET_REPO:
+        # yamllint disable-line rule:line-length
+        description: "The target GitHub repository needing the required workflow"
+        required: true
+        type: string
+
+concurrency:
+  # yamllint disable-line rule:line-length
+  group: required-change-isolation-${{ github.workflow }}-${{ github.event.inputs.GERRIT_BRANCH }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  cancel-in-progress: true
+
+# Default to no permissions; each job grants only what it needs.
+permissions: {}
+
+jobs:
+  clear-vote:
+    name: Clear change isolation vote
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Clear votes
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/gerrit-review-action@a1c036a59b94c8ab89de26d378f6a28cc7378b13  # v1.1.2
+        with:
+          host: ${{ vars.LFIT_GERRIT_SERVER }}
+          username: ${{ vars.LFIT_GERRIT_SSH_REQUIRED_USER }}
+          key: ${{ secrets.LFIT_GERRIT_SSH_REQUIRED_PRIVKEY }}
+          known_hosts: ${{ vars.LFIT_GERRIT_KNOWN_HOSTS }}
+          gerrit-change-number: ${{ inputs.GERRIT_CHANGE_NUMBER }}
+          gerrit-patchset-number: ${{ inputs.GERRIT_PATCHSET_NUMBER }}
+          vote-type: clear
+      - name: Allow replication
+        run: sleep 10s
+
+  change-isolation-verify:
+    name: Verify change isolation
+    needs: clear-vote
+    permissions:
+      contents: read
+    # yamllint disable-line rule:line-length
+    uses: lfit/releng-reusable-workflows/.github/workflows/gerrit-compose-required-change-isolation-verify.yaml@5278f76fc1d27c49d0c9f795a6ddea65eeb5c11b  # v0.8.1
+    with:
+      GERRIT_BRANCH: ${{ inputs.GERRIT_BRANCH }}
+      GERRIT_CHANGE_ID: ${{ inputs.GERRIT_CHANGE_ID }}
+      GERRIT_CHANGE_NUMBER: ${{ inputs.GERRIT_CHANGE_NUMBER }}
+      GERRIT_CHANGE_URL: ${{ inputs.GERRIT_CHANGE_URL }}
+      GERRIT_EVENT_TYPE: ${{ inputs.GERRIT_EVENT_TYPE }}
+      GERRIT_PATCHSET_NUMBER: ${{ inputs.GERRIT_PATCHSET_NUMBER }}
+      GERRIT_PATCHSET_REVISION: ${{ inputs.GERRIT_PATCHSET_REVISION }}
+      GERRIT_PROJECT: ${{ inputs.GERRIT_PROJECT }}
+      GERRIT_REFSPEC: ${{ inputs.GERRIT_REFSPEC }}
+      TARGET_REPO: ${{ inputs.TARGET_REPO }}
+
+  vote:
+    name: Set change isolation vote
+    if: ${{ always() }}
+    needs: [clear-vote, change-isolation-verify]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read  # workflow-conclusion reads sibling job results
+    steps:
+      - name: Get workflow conclusion
+        # yamllint disable-line rule:line-length
+        uses: im-open/workflow-conclusion@8eac7f17381a6917bc04fec3e2c92e70ebc37526  # v3.0.0
+      - name: Set vote
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/gerrit-review-action@a1c036a59b94c8ab89de26d378f6a28cc7378b13  # v1.1.2
+        with:
+          host: ${{ vars.LFIT_GERRIT_SERVER }}
+          username: ${{ vars.LFIT_GERRIT_SSH_REQUIRED_USER }}
+          key: ${{ secrets.LFIT_GERRIT_SSH_REQUIRED_PRIVKEY }}
+          known_hosts: ${{ vars.LFIT_GERRIT_KNOWN_HOSTS }}
+          gerrit-change-number: ${{ inputs.GERRIT_CHANGE_NUMBER }}
+          gerrit-patchset-number: ${{ inputs.GERRIT_PATCHSET_NUMBER }}
+          vote-type: ${{ env.WORKFLOW_CONCLUSION }}


### PR DESCRIPTION
## Summary

Adds a dedicated organization-level **required** workflow that enforces
change isolation on Gerrit patchsets, with its own **independent** Gerrit
voting so its result is reported separately from other required checks.

Part of the effort to modernise the Linux Foundation Gerrit CI and
standardise on the centrally-managed reusable workflows in
`lfit/releng-reusable-workflows` (mirrors the already-modernised ONAP
model).

## Design

The workflow is a thin dispatcher (`on: workflow_dispatch`, invoked by the
Gerrit → GitHub integration):

1. **Clear change isolation vote** — clears the prior vote via
   `lfreleng-actions/gerrit-review-action`.
2. **Verify change isolation** — delegates to the shared reusable
   `gerrit-compose-required-change-isolation-verify.yaml@v0.8.1`. No
   bespoke inline logic lives in this repository.
3. **Set change isolation vote** — votes the aggregated conclusion back to
   Gerrit (`im-open/workflow-conclusion@v3.0.0`).

## Notes / follow-ups

- All `uses:` references are SHA-pinned to their latest releases.
- Passes `zizmor --persona=auditor` with zero findings (empty default
  `permissions`, minimal per-job scopes, documented `actions: read`). The
  `secrets-outside-env` allow-list is provided by the companion config PR
  (#45), which should merge first.
- **Org provisioning required (admin):** this workflow relies on the
  existing `LFIT_GERRIT_*` org vars/secrets for its own vote steps, and the
  shared reusable additionally reads the plain `vars.GERRIT_URL` org
  variable for the Gerrit checkout. A repository **Ruleset** must map this
  workflow as a required check for the target Gerrit-mirrored repos.

## Validation

- `actionlint` → clean
- `yamllint` → clean
- `zizmor --persona=auditor --offline` → no findings
