### PR TITLE
CI: Add Gerrit bypassable RTDv3 verify workflow

### DIFF
--- a/.github/workflows/gerrit-required-bypassable-verify.yaml
+++ b/.github/workflows/gerrit-required-bypassable-verify.yaml
@@ -1,0 +1,123 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+name: Gerrit Required Bypassable Verify
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+    inputs:
+      GERRIT_BRANCH:
+        description: "Branch that change is against"
+        required: true
+        type: string
+      GERRIT_CHANGE_ID:
+        description: "The ID for the change"
+        required: true
+        type: string
+      GERRIT_CHANGE_NUMBER:
+        description: "The Gerrit number"
+        required: true
+        type: string
+      GERRIT_CHANGE_URL:
+        description: "URL to the change"
+        required: true
+        type: string
+      GERRIT_EVENT_TYPE:
+        description: "Type of Gerrit event"
+        required: true
+        type: string
+      GERRIT_PATCHSET_NUMBER:
+        description: "The patch number for the change"
+        required: true
+        type: string
+      GERRIT_PATCHSET_REVISION:
+        description: "The revision sha"
+        required: true
+        type: string
+      GERRIT_PROJECT:
+        description: "Project in Gerrit"
+        required: true
+        type: string
+      GERRIT_REFSPEC:
+        description: "Gerrit refspec of change"
+        required: true
+        type: string
+      TARGET_REPO:
+        # yamllint disable-line rule:line-length
+        description: "The target GitHub repository needing the bypassable workflow"
+        required: true
+        type: string
+
+concurrency:
+  # yamllint disable-line rule:line-length
+  group: required-bypassable-verify-${{ github.workflow }}-${{ github.event.inputs.GERRIT_BRANCH }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  cancel-in-progress: true
+
+# Default to no permissions; each job grants only what it needs.
+permissions: {}
+
+jobs:
+  clear-vote:
+    name: Clear bypassable vote
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Clear votes
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/gerrit-review-action@a1c036a59b94c8ab89de26d378f6a28cc7378b13  # v1.1.2
+        with:
+          host: ${{ vars.LFIT_GERRIT_SERVER }}
+          username: ${{ vars.LFIT_GERRIT_SSH_BYPASSABLE_USER }}
+          key: ${{ secrets.LFIT_GERRIT_SSH_BYPASSABLE_PRIVKEY }}
+          known_hosts: ${{ vars.LFIT_GERRIT_KNOWN_HOSTS }}
+          gerrit-change-number: ${{ inputs.GERRIT_CHANGE_NUMBER }}
+          gerrit-patchset-number: ${{ inputs.GERRIT_PATCHSET_NUMBER }}
+          vote-type: clear
+      - name: Allow replication
+        run: sleep 10s
+
+  rtd-verify:
+    name: Read the Docs verify
+    needs: clear-vote
+    permissions:
+      contents: read
+    # yamllint disable-line rule:line-length
+    uses: lfit/releng-reusable-workflows/.github/workflows/gerrit-compose-required-rtdv3-verify.yaml@5278f76fc1d27c49d0c9f795a6ddea65eeb5c11b  # v0.8.1
+    with:
+      GERRIT_BRANCH: ${{ inputs.GERRIT_BRANCH }}
+      GERRIT_CHANGE_ID: ${{ inputs.GERRIT_CHANGE_ID }}
+      GERRIT_CHANGE_NUMBER: ${{ inputs.GERRIT_CHANGE_NUMBER }}
+      GERRIT_CHANGE_URL: ${{ inputs.GERRIT_CHANGE_URL }}
+      GERRIT_EVENT_TYPE: ${{ inputs.GERRIT_EVENT_TYPE }}
+      GERRIT_PATCHSET_NUMBER: ${{ inputs.GERRIT_PATCHSET_NUMBER }}
+      GERRIT_PATCHSET_REVISION: ${{ inputs.GERRIT_PATCHSET_REVISION }}
+      GERRIT_PROJECT: ${{ inputs.GERRIT_PROJECT }}
+      GERRIT_REFSPEC: ${{ inputs.GERRIT_REFSPEC }}
+      TARGET_REPO: ${{ inputs.TARGET_REPO }}
+    secrets:
+      RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
+
+  vote:
+    name: Set bypassable vote
+    if: ${{ always() }}
+    needs: [clear-vote, rtd-verify]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read  # workflow-conclusion reads sibling job results
+    steps:
+      - name: Get workflow conclusion
+        # yamllint disable-line rule:line-length
+        uses: im-open/workflow-conclusion@8eac7f17381a6917bc04fec3e2c92e70ebc37526  # v3.0.0
+      - name: Set vote
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/gerrit-review-action@a1c036a59b94c8ab89de26d378f6a28cc7378b13  # v1.1.2
+        with:
+          host: ${{ vars.LFIT_GERRIT_SERVER }}
+          username: ${{ vars.LFIT_GERRIT_SSH_BYPASSABLE_USER }}
+          key: ${{ secrets.LFIT_GERRIT_SSH_BYPASSABLE_PRIVKEY }}
+          known_hosts: ${{ vars.LFIT_GERRIT_KNOWN_HOSTS }}
+          gerrit-change-number: ${{ inputs.GERRIT_CHANGE_NUMBER }}
+          gerrit-patchset-number: ${{ inputs.GERRIT_PATCHSET_NUMBER }}
+          vote-type: ${{ env.WORKFLOW_CONCLUSION }}


### PR DESCRIPTION
## Summary

Adds an organization-level **bypassable** required workflow that verifies
Read the Docs (RTDv3) documentation builds for Gerrit patchsets, voting
with a dedicated *bypassable* service account so maintainers can override
the result when necessary.

Part of the effort to modernise the Linux Foundation Gerrit CI and
standardise on the centrally-managed reusable workflows in
`lfit/releng-reusable-workflows`.

## Design

Thin dispatcher (`on: workflow_dispatch`, invoked by the Gerrit → GitHub
integration):

1. **Clear bypassable vote** — clears the prior vote using the bypassable
   service account.
2. **Read the Docs verify** — delegates to the shared reusable
   `gerrit-compose-required-rtdv3-verify.yaml@v0.8.1`, forwarding the RTD
   API token.
3. **Set bypassable vote** — votes the aggregated conclusion back to
   Gerrit.

Unlike ONAP's equivalent, this deliberately **omits the bespoke inline
`doc-rules-compose` logic** — all shared behaviour stays in the reusable,
per the goal of standardising on centrally-managed CI.

## Notes / follow-ups

- All `uses:` references are SHA-pinned to their latest releases.
- Passes `zizmor --persona=auditor` with zero findings. The
  `secrets-outside-env` allow-list is provided by the companion config PR
  (#45), which should merge first.
- **Org provisioning required (admin):** relies on `LFIT_GERRIT_SERVER`,
  `LFIT_GERRIT_KNOWN_HOSTS`, `LFIT_GERRIT_SSH_BYPASSABLE_USER` /
  `LFIT_GERRIT_SSH_BYPASSABLE_PRIVKEY`, the `RTD_TOKEN` secret, and the
  shared reusable's `vars.GERRIT_URL`. A repository **Ruleset** must map
  this workflow as a bypassable required check for the Gerrit-mirrored
  docs repositories.

## Validation

- `actionlint` → clean
- `yamllint` → clean
- `zizmor --persona=auditor --offline` → no findings
