### PR TITLE
CI: Add Gerrit RTDv3 merge workflow

### DIFF
--- a/.github/workflows/gerrit-required-merge.yaml
+++ b/.github/workflows/gerrit-required-merge.yaml
@@ -1,0 +1,125 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+name: Gerrit Required Merge
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+    inputs:
+      GERRIT_BRANCH:
+        description: "Branch that change is against"
+        required: true
+        type: string
+      GERRIT_CHANGE_ID:
+        description: "The ID for the change"
+        required: true
+        type: string
+      GERRIT_CHANGE_NUMBER:
+        description: "The Gerrit number"
+        required: true
+        type: string
+      GERRIT_CHANGE_URL:
+        description: "URL to the change"
+        required: true
+        type: string
+      GERRIT_EVENT_TYPE:
+        description: "Type of Gerrit event"
+        required: true
+        type: string
+      GERRIT_PATCHSET_NUMBER:
+        description: "The patch number for the change"
+        required: true
+        type: string
+      GERRIT_PATCHSET_REVISION:
+        description: "The revision sha"
+        required: true
+        type: string
+      GERRIT_PROJECT:
+        description: "Project in Gerrit"
+        required: true
+        type: string
+      GERRIT_REFSPEC:
+        description: "Gerrit refspec of change"
+        required: true
+        type: string
+      TARGET_REPO:
+        # yamllint disable-line rule:line-length
+        description: "The target GitHub repository needing the required workflow"
+        required: true
+        type: string
+
+concurrency:
+  # yamllint disable-line rule:line-length
+  group: required-merge-${{ github.workflow }}-${{ github.event.inputs.GERRIT_CHANGE_ID || github.run_id }}
+  cancel-in-progress: true
+
+# Default to no permissions; each job grants only what it needs.
+permissions: {}
+
+jobs:
+  notify:
+    name: Notify merge start
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Notify job start
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/gerrit-review-action@a1c036a59b94c8ab89de26d378f6a28cc7378b13  # v1.1.2
+        with:
+          host: ${{ vars.LFIT_GERRIT_SERVER }}
+          username: ${{ vars.LFIT_GERRIT_SSH_REQUIRED_USER }}
+          key: ${{ secrets.LFIT_GERRIT_SSH_REQUIRED_PRIVKEY }}
+          known_hosts: ${{ vars.LFIT_GERRIT_KNOWN_HOSTS }}
+          gerrit-change-number: ${{ inputs.GERRIT_CHANGE_NUMBER }}
+          gerrit-patchset-number: ${{ inputs.GERRIT_PATCHSET_NUMBER }}
+          vote-type: clear
+          comment-only: "true"
+      - name: Allow replication
+        run: sleep 10s
+
+  rtd-merge:
+    name: Read the Docs merge
+    needs: notify
+    permissions:
+      contents: read
+    # yamllint disable-line rule:line-length
+    uses: lfit/releng-reusable-workflows/.github/workflows/gerrit-compose-required-rtdv3-merge.yaml@5278f76fc1d27c49d0c9f795a6ddea65eeb5c11b  # v0.8.1
+    with:
+      GERRIT_BRANCH: ${{ inputs.GERRIT_BRANCH }}
+      GERRIT_CHANGE_ID: ${{ inputs.GERRIT_CHANGE_ID }}
+      GERRIT_CHANGE_NUMBER: ${{ inputs.GERRIT_CHANGE_NUMBER }}
+      GERRIT_CHANGE_URL: ${{ inputs.GERRIT_CHANGE_URL }}
+      GERRIT_EVENT_TYPE: ${{ inputs.GERRIT_EVENT_TYPE }}
+      GERRIT_PATCHSET_NUMBER: ${{ inputs.GERRIT_PATCHSET_NUMBER }}
+      GERRIT_PATCHSET_REVISION: ${{ inputs.GERRIT_PATCHSET_REVISION }}
+      GERRIT_PROJECT: ${{ inputs.GERRIT_PROJECT }}
+      GERRIT_REFSPEC: ${{ inputs.GERRIT_REFSPEC }}
+      TARGET_REPO: ${{ inputs.TARGET_REPO }}
+    secrets:
+      RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
+
+  report-status:
+    name: Report merge status
+    if: ${{ always() }}
+    needs: [notify, rtd-merge]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read  # workflow-conclusion reads sibling job results
+    steps:
+      - name: Get workflow conclusion
+        # yamllint disable-line rule:line-length
+        uses: im-open/workflow-conclusion@8eac7f17381a6917bc04fec3e2c92e70ebc37526  # v3.0.0
+      - name: Report workflow conclusion
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/gerrit-review-action@a1c036a59b94c8ab89de26d378f6a28cc7378b13  # v1.1.2
+        with:
+          host: ${{ vars.LFIT_GERRIT_SERVER }}
+          username: ${{ vars.LFIT_GERRIT_SSH_REQUIRED_USER }}
+          key: ${{ secrets.LFIT_GERRIT_SSH_REQUIRED_PRIVKEY }}
+          known_hosts: ${{ vars.LFIT_GERRIT_KNOWN_HOSTS }}
+          gerrit-change-number: ${{ inputs.GERRIT_CHANGE_NUMBER }}
+          gerrit-patchset-number: ${{ inputs.GERRIT_PATCHSET_NUMBER }}
+          vote-type: ${{ env.WORKFLOW_CONCLUSION }}
+          comment-only: "true"


### PR DESCRIPTION
## Summary

Adds an organization-level required **merge** workflow that publishes Read
the Docs (RTDv3) documentation once a Gerrit change merges.

Part of the effort to modernise the Linux Foundation Gerrit CI and
standardise on the centrally-managed reusable workflows in
`lfit/releng-reusable-workflows`.

## Design

Thin dispatcher (`on: workflow_dispatch`, invoked by the Gerrit → GitHub
integration on merge):

1. **Notify merge start** — posts a start comment to Gerrit (comment-only,
   the change has already merged).
2. **Read the Docs merge** — delegates the publish to the shared reusable
   `gerrit-compose-required-rtdv3-merge.yaml@v0.8.1`, forwarding the RTD
   API token.
3. **Report merge status** — reports the aggregated conclusion back to the
   change as a comment.

## Notes / follow-ups

- All `uses:` references are SHA-pinned to their latest releases.
- Passes `zizmor --persona=auditor` with zero findings. The
  `secrets-outside-env` allow-list is provided by the companion config PR
  (#45), which should merge first.
- **Org provisioning required (admin):** relies on `LFIT_GERRIT_SERVER`,
  `LFIT_GERRIT_KNOWN_HOSTS`, `LFIT_GERRIT_SSH_REQUIRED_USER` /
  `LFIT_GERRIT_SSH_REQUIRED_PRIVKEY`, the `RTD_TOKEN` secret, and the shared
  reusable's `vars.GERRIT_URL`. A repository **Ruleset** must wire this
  workflow to run on merge for the Gerrit-mirrored docs repositories.
- Enable this only if LF wants docs published via RTDv3 (companion to the
  bypassable verify workflow in #47).

## Validation

- `actionlint` → clean
- `yamllint` → clean
- `zizmor --persona=auditor --offline` → no findings
